### PR TITLE
NSHv2 Fixes

### DIFF
--- a/src/applications/SRAnonTool/CTP_DicomToText.py
+++ b/src/applications/SRAnonTool/CTP_DicomToText.py
@@ -215,8 +215,13 @@ if __name__ == '__main__':
         mongo_semehr_pass = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('Password',{})
         mongo_semehr_db   = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('DatabaseName',{})
 
-    log_dir = cfg_dict['LoggingOptions']['LogsRoot']
-    root_dir = cfg_dict['FileSystemOptions']['FileSystemRoot']
+    log_dir = os.environ.get("SMI_LOGS_ROOT", None)
+    if not log_dir:
+        log_dir = cfg_dict['LoggingOptions']['LogsRoot']
+
+    root_dir = os.environ.get("SMI_PACS_ROOT", None)
+    if not root_dir:
+        root_dir = cfg_dict['FileSystemOptions']['FileSystemRoot']
 
     # ---------------------------------------------------------------------
     # Now we know the LogsRoot we can set up logging

--- a/src/applications/SRAnonTool/CTP_DicomToText.py
+++ b/src/applications/SRAnonTool/CTP_DicomToText.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
 
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='SR-to-Anon')
-    parser.add_argument('-y', dest='yamlfile', action="append", help='path to yaml config file (can be used more than once)')
+    parser.add_argument('-y', dest='yamlfile', action="append", default=[], help='path to yaml config file (can be used more than once)')
     parser.add_argument('-i', dest='input', action="store", help='SOPInstanceUID or path to raw DICOM file from which text will be redacted')
     parser.add_argument('-o', dest='output_dir', action="store", help='path to directory where extracted text will be written')
     parser.add_argument('-m', dest='metadata_dir', action="store", help='path to directory where extracted metadata will be written')
@@ -195,8 +195,6 @@ if __name__ == '__main__':
         args.output_dir = '.'
 
     cfg_dict = {}
-    if not args.yamlfile:
-        args.yamlfile = [os.path.join(os.environ['SMI_ROOT'], 'configs', 'smi_dataExtract.yaml')]
     for cfg_file in args.yamlfile:
         with open(cfg_file, 'r') as fd:
             # Merge all the yaml dicts into one

--- a/src/applications/SRAnonTool/CTP_DicomToText.py
+++ b/src/applications/SRAnonTool/CTP_DicomToText.py
@@ -229,7 +229,7 @@ if __name__ == '__main__':
 
     # ---------------------------------------------------------------------
     # Initialise the PatientID mapping by opening a DB connection
-    if cfg_dict:
+    if cfg_dict and args.metadata_dir is not None:
         try:
             IdentifierMapper.CHItoEUPI(cfg_dict)
         except:

--- a/src/applications/SRAnonTool/CTP_DicomToText.py
+++ b/src/applications/SRAnonTool/CTP_DicomToText.py
@@ -186,6 +186,7 @@ if __name__ == '__main__':
     parser.add_argument('--semehr-unique', dest='semehr_unique', action="store_true", help='only extract from MongoDB/dicom if not already in MongoDB/semehr')
     parser.add_argument('--replace-html', action="store", help='replace HTML with a character, default is dot (.), or "squash" to eliminate')
     parser.add_argument('--replace-newlines', action="store", help='replace carriage returns and newlines with a character (e.g. a space) or "squash" to eliminate')
+    parser.add_argument("--use-mongodb", action="store_true", help="Use MongoDB for reading/writing")
     args = parser.parse_args()
     if not args.input:
         parser.print_help()
@@ -201,17 +202,18 @@ if __name__ == '__main__':
             # Merge all the yaml dicts into one
             cfg_dict = Merger([(list, ["append"]),(dict, ["merge"])],["override"],["override"]).merge(cfg_dict, yaml.safe_load(fd))
 
-    # For reading SRs
-    mongo_dicom_host = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('HostName',{})
-    mongo_dicom_user = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('UserName',{})
-    mongo_dicom_pass = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('Password',{})
-    mongo_dicom_db   = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('DatabaseName',{})
+    if args.use_mongodb:
+        # For reading SRs
+        mongo_dicom_host = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('HostName',{})
+        mongo_dicom_user = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('UserName',{})
+        mongo_dicom_pass = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('Password',{})
+        mongo_dicom_db   = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('DatabaseName',{})
 
-    # For writing annotations
-    mongo_semehr_host = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('HostName',{})
-    mongo_semehr_user = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('UserName',{})
-    mongo_semehr_pass = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('Password',{})
-    mongo_semehr_db   = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('DatabaseName',{})
+        # For writing annotations
+        mongo_semehr_host = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('HostName',{})
+        mongo_semehr_user = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('UserName',{})
+        mongo_semehr_pass = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('Password',{})
+        mongo_semehr_db   = cfg_dict.get('MongoDatabases', {}).get('SemEHRStoreOptions',{}).get('DatabaseName',{})
 
     log_dir = cfg_dict['LoggingOptions']['LogsRoot']
     root_dir = cfg_dict['FileSystemOptions']['FileSystemRoot']

--- a/src/applications/SRAnonTool/CTP_DicomToText.py
+++ b/src/applications/SRAnonTool/CTP_DicomToText.py
@@ -200,6 +200,7 @@ if __name__ == '__main__':
             # Merge all the yaml dicts into one
             cfg_dict = Merger([(list, ["append"]),(dict, ["merge"])],["override"],["override"]).merge(cfg_dict, yaml.safe_load(fd))
 
+    mongo_dicom_db = {}
     if args.use_mongodb:
         # For reading SRs
         mongo_dicom_host = cfg_dict.get('MongoDatabases', {}).get('DicomStoreOptions',{}).get('HostName',{})

--- a/src/applications/SRAnonTool/CTP_XMLToDicom.py
+++ b/src/applications/SRAnonTool/CTP_XMLToDicom.py
@@ -50,9 +50,13 @@ if __name__ == "__main__":
             # Merge all the yaml dicst into one
             cfg_dict = Merger([(list, ["append"]),(dict, ["merge"])],["override"],["override"]).merge(cfg_dict, yaml.safe_load(fd))
 
-    log_dir = cfg_dict['LoggingOptions']['LogsRoot']
-    root_dir = cfg_dict['FileSystemOptions']['FileSystemRoot']
-    extract_dir = cfg_dict['FileSystemOptions']['ExtractRoot']
+    log_dir = os.environ.get("SMI_LOGS_ROOT", None)
+    if not log_dir:
+        log_dir = cfg_dict['LoggingOptions']['LogsRoot']
+
+    root_dir = os.environ.get("SMI_PACS_ROOT", None)
+    if not root_dir:
+        root_dir = cfg_dict['FileSystemOptions']['FileSystemRoot']
 
     # ---------------------------------------------------------------------
     # Now we know the LogsRoot we can set up logging

--- a/src/applications/SRAnonTool/CTP_XMLToDicom.py
+++ b/src/applications/SRAnonTool/CTP_XMLToDicom.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Anon-to-SR')
-    parser.add_argument('-y', dest='yamlfile', action="append", help='path to yaml extract config file (can be used more than once)')
+    parser.add_argument('-y', dest='yamlfile', action="append", default=[], help='path to yaml extract config file (can be used more than once)')
     parser.add_argument('-i', dest='input_dcm', action="store", help='Path to raw DICOM file')
     parser.add_argument('-x', dest='input_xml', action="store", help='Path to annotation XML file')
     parser.add_argument('-o', dest='output_dcm', action="store", help='Path to anonymised DICOM file to have redacted text inserted')
@@ -43,8 +43,6 @@ if __name__ == "__main__":
         exit(1)
 
     cfg_dict = {}
-    if not args.yamlfile:
-        args.yamlfile = [os.path.join(os.environ['SMI_ROOT'], 'configs', 'smi_dataExtract.yaml')]
     for cfg_file in args.yamlfile:
         with open(cfg_file, 'r') as fd:
             # Merge all the yaml dicst into one

--- a/src/applications/SRAnonTool/requirements.txt
+++ b/src/applications/SRAnonTool/requirements.txt
@@ -1,3 +1,4 @@
 deepmerge
 pydicom
 pymongo
+pyyaml

--- a/src/applications/semehr_anon.py
+++ b/src/applications/semehr_anon.py
@@ -168,6 +168,8 @@ def main():
             args.input, args.output, args.semehr_anon_cfg_file,
             write_xml=args.write_xml, write_all=True,
         )
+    else:
+        raise FileNotFoundError(f"Input {args.input} is not a file or a directory")
 
 
 if __name__ == '__main__':

--- a/src/applications/semehr_anon.py
+++ b/src/applications/semehr_anon.py
@@ -30,7 +30,7 @@ use_spacy = False
 empty_knowtator_xml_document_string = '<?xml version="1.0" ?>\n<annotations>\n</annotations>\n'
 
 
-def anonymise_dir(input_dir, output_dir, semehr_dir, semehr_anon_cfg_file, write_xml = False, write_all = False):
+def anonymise_dir(input_dir, output_dir, semehr_anon_cfg_file, write_xml = False, write_all = False):
 
     input_dir = os.path.abspath(input_dir)
     output_dir = os.path.abspath(output_dir)
@@ -105,7 +105,7 @@ def anonymise_dir(input_dir, output_dir, semehr_dir, semehr_anon_cfg_file, write
     return
 
 
-def anonymise_file(input_file, output_file, semehr_dir, semehr_anon_cfg_file, write_xml = False, write_all = False):
+def anonymise_file(input_file, output_file, semehr_anon_cfg_file, write_xml = False, write_all = False):
     # The anonymiser works on whole directories so
     # create temporary input/output directories and copy the file there.
     input_file = os.path.abspath(input_file)
@@ -114,7 +114,7 @@ def anonymise_file(input_file, output_file, semehr_dir, semehr_anon_cfg_file, wr
     output_dir = tempfile.TemporaryDirectory()
     shutil.copyfile(input_file, os.path.join(input_dir.name, os.path.basename(input_file)))
     anonymise_dir(
-        input_dir.name, output_dir.name, semehr_dir, semehr_anon_cfg_file,
+        input_dir.name, output_dir.name, semehr_anon_cfg_file,
         write_xml=write_xml, write_all=write_all,
     )
     shutil.copyfile(os.path.join(output_dir.name, os.path.basename(input_file)), output_file)
@@ -129,7 +129,6 @@ def anonymise_file(input_file, output_file, semehr_dir, semehr_anon_cfg_file, wr
 
 def main():
     global use_spacy
-    semehr_dir = None
 
 	# Configure logging
     if not os.environ.get('SMI_LOGS_ROOT'): raise Exception('Environment variable SMI_LOGS_ROOT must be set')
@@ -148,7 +147,6 @@ def main():
     parser.add_argument('-i', dest='input', action="store", help='directory of text, or filename of one text file')
     parser.add_argument('-o', dest='output', action="store", help='path to output filename or directory where redacted text files will be written')
     parser.add_argument('-x', '--xml', dest='write_xml', action="store_true", help='write knowtator.xml in output directory for all input files', default=False)
-    parser.add_argument('-s', dest='semehr_dir', action="store", help='path to parent of CogStack-SemEHR directory')
     parser.add_argument('-c', dest='semehr_anon_cfg_file', action="store", help='path to the anon config file e.g., "anonymisation_task.json"')
     parser.add_argument('--spacy', dest='spacy', action='store_true', help='use SpaCy to identify names')
     args = parser.parse_args()
@@ -159,24 +157,15 @@ def main():
     if args.spacy:
     	use_spacy = True # XXX global
 
-    if os.path.isdir(os.path.expandvars("$HOME/SemEHR")):
-        semehr_dir = os.path.expandvars("$HOME/SemEHR")
-    if os.path.isdir('/opt/semehr'):
-        semehr_dir = '/opt/semehr'
-    if args.semehr_dir:
-        semehr_dir = args.semehr_dir
-    if not semehr_dir:
-        raise Exception('cannot find CogStack-SemEHR in ~/SemEHR or /opt/semehr and -s option not used')
-
     if os.path.isfile(args.input):
         anonymise_file(
-            args.input, args.output, semehr_dir, args.semehr_anon_cfg_file,
+            args.input, args.output, args.semehr_anon_cfg_file,
             write_xml=args.write_xml, write_all=True,
         )
 
     elif os.path.isdir(args.input):
         anonymise_dir(
-            args.input, args.output, semehr_dir, args.semehr_anon_cfg_file,
+            args.input, args.output, args.semehr_anon_cfg_file,
             write_xml=args.write_xml, write_all=True,
         )
 

--- a/src/applications/semehr_anon.py
+++ b/src/applications/semehr_anon.py
@@ -144,10 +144,10 @@ def main():
 
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Redact text given knowtator XML')
-    parser.add_argument('-i', dest='input', action="store", help='directory of text, or filename of one text file')
-    parser.add_argument('-o', dest='output', action="store", help='path to output filename or directory where redacted text files will be written')
+    parser.add_argument('-i', dest='input', action="store", required=True, help='directory of text, or filename of one text file')
+    parser.add_argument('-o', dest='output', action="store", required=True, help='path to output filename or directory where redacted text files will be written')
     parser.add_argument('-x', '--xml', dest='write_xml', action="store_true", help='write knowtator.xml in output directory for all input files', default=False)
-    parser.add_argument('-c', dest='semehr_anon_cfg_file', action="store", help='path to the anon config file e.g., "anonymisation_task.json"')
+    parser.add_argument('-c', dest='semehr_anon_cfg_file', action="store", required=True, help='path to the anon config file e.g., "anonymisation_task.json"')
     parser.add_argument('--spacy', dest='spacy', action='store_true', help='use SpaCy to identify names')
     args = parser.parse_args()
     if not args.input:

--- a/src/applications/semehr_anon.py
+++ b/src/applications/semehr_anon.py
@@ -44,7 +44,6 @@ def anonymise_dir(input_dir, output_dir, semehr_dir, semehr_anon_cfg_file, write
     cfg_json['anonymisation_output'] = output_dir
     cfg_json['extracted_phi'] = phi_file
     cfg_json['grouped_phi_output'] = '/dev/null'
-    cfg_json['rules_folder'] = os.path.join(semehr_dir, 'CogStack-SemEHR', 'anonymisation/conf/rules')
     if 'logging_file' in cfg_json:
         del cfg_json['logging_file']
     cfg_json['annotation_mode'] = False

--- a/src/applications/semehr_anon.py
+++ b/src/applications/semehr_anon.py
@@ -150,6 +150,7 @@ def main():
     parser.add_argument('-o', dest='output', action="store", help='path to output filename or directory where redacted text files will be written')
     parser.add_argument('-x', '--xml', dest='write_xml', action="store_true", help='write knowtator.xml in output directory for all input files', default=False)
     parser.add_argument('-s', dest='semehr_dir', action="store", help='path to parent of CogStack-SemEHR directory')
+    parser.add_argument('-c', dest='semehr_anon_cfg_file', action="store", help='path to the anon config file e.g., "anonymisation_task.json"')
     parser.add_argument('--spacy', dest='spacy', action='store_true', help='use SpaCy to identify names')
     args = parser.parse_args()
     if not args.input:
@@ -167,17 +168,16 @@ def main():
         semehr_dir = args.semehr_dir
     if not semehr_dir:
         raise Exception('cannot find CogStack-SemEHR in ~/SemEHR or /opt/semehr and -s option not used')
-    semehr_anon_cfg_file = os.path.join(semehr_dir, 'CogStack-SemEHR', 'anonymisation', 'conf', 'anonymisation_task.json') # i.e. /opt/semehr/CogStack-SemEHR/anonymisation/conf/anonymisation_task.json
 
     if os.path.isfile(args.input):
         anonymise_file(
-            args.input, args.output, semehr_dir, semehr_anon_cfg_file,
+            args.input, args.output, semehr_dir, args.semehr_anon_cfg_file,
             write_xml=args.write_xml, write_all=True,
         )
 
     elif os.path.isdir(args.input):
         anonymise_dir(
-            args.input, args.output, semehr_dir, semehr_anon_cfg_file,
+            args.input, args.output, semehr_dir, args.semehr_anon_cfg_file,
             write_xml=args.write_xml, write_all=True,
         )
 

--- a/src/library/setup.py
+++ b/src/library/setup.py
@@ -32,11 +32,6 @@ def translate_req(req):
 def version_from_txt():
     with open('version.txt') as fd:
         ver = next(fd).strip()
-    version = ver.split('.')
-    version[2] = str(int(version[2]) + 1)
-    vernext = '.'.join(version)
-    with open('version.txt', 'w') as fd:
-        print(vernext, file=fd)
     return ver
 
 setup(


### PR DESCRIPTION
Several minor changes to generalise the configuration and make SR anon work in NSHv2.

806b4d0 add default mongo_dicom_db
13f3983 don't increase version on each install
25e3644 fail if input file/dir is missing
18db42d mark required arguments as such
fab3715 remove unused semehr_dir
7a00e6e don't overwrite rules_folder
0f40088 allow passing anon conf directly
cf83c18 don't assume old config paths
a48a23a add missing pyyaml dep
1cf95c1 remove unused extract_dir and read env vars first before configs
d920ea7 read env vars first before configs
d875d56 only init CHItoEUPI if needed
30bd6e1 only parse mongodb options if needed